### PR TITLE
SQL, API, and rate-limiting improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ var thresh_query = `SELECT ceil(avg(favourites_count)) AS threshold
 var query = `SELECT id, created_at
   FROM public_toots
   WHERE
-    favourites_count > (` + thresh_query + `)
+    favourites_count >= (` + thresh_query + `)
     AND NOT EXISTS (
       SELECT 1
       FROM public_toots AS pt2


### PR DESCRIPTION
Instead of caching, uses a subquery to determine if the toot has already been boosted by ourself.

Snags our current account ID from the API so we can do the aforementioned determination.

Also puts a LIMIT clause on the query so that we only boost a certain number of toots per run (default: 2).  This particular adjustment was courtesy of me forgetting to restart Ambassador after a reboot...

This pull request is a bit of a congealed mess.  I, or someone else, could split it into a couple distinct patches without too much effort I think.